### PR TITLE
feat: add get_path function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,8 @@ mod rustinfo;
 mod triple;
 pub mod types;
 
+use std::path::Path;
+
 use crate::types::RustInfo;
 
 /// Loads and returns the current rust compiler version and setup.<br>
@@ -211,5 +213,29 @@ use crate::types::RustInfo;
 /// }
 /// ```
 pub fn get() -> RustInfo {
-    rustinfo::get()
+    rustinfo::get(None)
+}
+
+/// Loads and returns the current rust compiler version and setup for a specified path.<br>
+/// In case partial data is not available, those values will be set to Option::None.
+///
+/// # Example
+///
+/// ```
+/// fn main() {
+///     let path = Path::new("./");
+///     let rust_info = rust_info::get_path(&path);
+///
+///     println!("Version: {}", rust_info.version.unwrap());
+///     println!("Channel: {:#?}", rust_info.channel.unwrap());
+///     println!("Target Arch: {}", rust_info.target_arch.unwrap_or("unknown".to_string()));
+///     println!("Target Env: {}", rust_info.target_env.unwrap_or("unknown".to_string()));
+///     println!("Target OS: {}", rust_info.target_os.unwrap_or("unknown".to_string()));
+///     println!("Target Pointer Width: {}", rust_info.target_pointer_width.unwrap_or("unknown".to_string()));
+///     println!("Target Vendor: {}", rust_info.target_vendor.unwrap_or("unknown".to_string()));
+///     println!("Target Triple: {}", rust_info.target_triple.unwrap_or("unknown".to_string()));
+/// }
+/// ```
+pub fn get_path(path: &Path) -> RustInfo {
+    rustinfo::get(Some(path))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,9 +189,35 @@ mod rustinfo;
 mod triple;
 pub mod types;
 
-use std::path::Path;
+use std::{borrow::Cow, path::Path};
 
 use crate::types::RustInfo;
+
+/// Options used for querying rust info
+#[derive(Debug, Clone)]
+pub struct Options<'path> {
+    /// Optionally override working directory used for querying `rustc`
+    pub path: Option<Cow<'path, Path>>,
+}
+
+impl<'path> Default for Options<'path> {
+    fn default() -> Self {
+        Self { path: None }
+    }
+}
+
+impl<'path> Options<'path> {
+    /// Helper for calling `default`
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the `path` option
+    pub fn path(mut self, path: Option<Cow<'path, Path>>) -> Self {
+        self.path = path;
+        self
+    }
+}
 
 /// Loads and returns the current rust compiler version and setup.<br>
 /// In case partial data is not available, those values will be set to Option::None.
@@ -213,7 +239,7 @@ use crate::types::RustInfo;
 /// }
 /// ```
 pub fn get() -> RustInfo {
-    rustinfo::get(None)
+    get_with_options(&Options::default())
 }
 
 /// Loads and returns the current rust compiler version and setup for a specified path.<br>
@@ -223,8 +249,8 @@ pub fn get() -> RustInfo {
 ///
 /// ```
 /// fn main() {
-///     let path = Path::new("./");
-///     let rust_info = rust_info::get_path(&path);
+///     let opts = rust_info::Options::new().path(Some(std::path::Path::new("./").into()));
+///     let rust_info = rust_info::get_with_options(&opts);
 ///
 ///     println!("Version: {}", rust_info.version.unwrap());
 ///     println!("Channel: {:#?}", rust_info.channel.unwrap());
@@ -236,6 +262,6 @@ pub fn get() -> RustInfo {
 ///     println!("Target Triple: {}", rust_info.target_triple.unwrap_or("unknown".to_string()));
 /// }
 /// ```
-pub fn get_path(path: &Path) -> RustInfo {
-    rustinfo::get(Some(path))
+pub fn get_with_options(options: &Options) -> RustInfo {
+    rustinfo::get(options)
 }

--- a/src/rustinfo.rs
+++ b/src/rustinfo.rs
@@ -11,6 +11,7 @@ use crate::triple;
 use crate::types::{RustChannel, RustInfo};
 use std::collections::HashMap;
 use std::io::Error;
+use std::path::Path;
 use std::process::{Command, ExitStatus};
 
 /// Returns the exit code (-1 if no exit code found)
@@ -30,8 +31,16 @@ fn get_exit_code(exit_status: Result<ExitStatus, Error>) -> i32 {
     }
 }
 
-fn load_version(rust_info: &mut RustInfo) {
-    let result = Command::new("rustc").arg("--version").output();
+fn load_version(rust_info: &mut RustInfo, path: Option<&Path>) {
+    let mut command = Command::new("rustc");
+
+    command.arg("--version");
+
+    if let Some(directory) = path {
+        command.current_dir(directory);
+    }
+
+    let result = command.output();
 
     match result {
         Ok(output) => {
@@ -64,8 +73,16 @@ fn load_version(rust_info: &mut RustInfo) {
     };
 }
 
-fn load_setup(rust_info: &mut RustInfo) {
-    let result = Command::new("rustc").arg("--print").arg("cfg").output();
+fn load_setup(rust_info: &mut RustInfo, path: Option<&Path>) {
+    let mut command = Command::new("rustc");
+
+    command.arg("--print").arg("cfg");
+
+    if let Some(directory) = path {
+        command.current_dir(directory);
+    }
+
+    let result = command.output();
 
     match result {
         Ok(output) => {
@@ -118,12 +135,12 @@ fn load_setup(rust_info: &mut RustInfo) {
 
 /// Loads and returns the current rust compiler version and setup.<br>
 /// In case partial data is not available, those values will be set to Option::None.
-pub(crate) fn get() -> RustInfo {
+pub(crate) fn get(path: Option<&Path>) -> RustInfo {
     let mut rust_info = RustInfo::new();
 
-    load_version(&mut rust_info);
+    load_version(&mut rust_info, path);
 
-    load_setup(&mut rust_info);
+    load_setup(&mut rust_info, path);
 
     triple::load(&mut rust_info);
 

--- a/src/rustinfo.rs
+++ b/src/rustinfo.rs
@@ -7,11 +7,10 @@
 #[path = "./rustinfo_test.rs"]
 mod rustinfo_test;
 
-use crate::triple;
 use crate::types::{RustChannel, RustInfo};
+use crate::{triple, Options};
 use std::collections::HashMap;
 use std::io::Error;
-use std::path::Path;
 use std::process::{Command, ExitStatus};
 
 /// Returns the exit code (-1 if no exit code found)
@@ -31,12 +30,12 @@ fn get_exit_code(exit_status: Result<ExitStatus, Error>) -> i32 {
     }
 }
 
-fn load_version(rust_info: &mut RustInfo, path: Option<&Path>) {
+fn load_version(rust_info: &mut RustInfo, options: &Options) {
     let mut command = Command::new("rustc");
 
     command.arg("--version");
 
-    if let Some(directory) = path {
+    if let Some(directory) = &options.path {
         command.current_dir(directory);
     }
 
@@ -73,12 +72,12 @@ fn load_version(rust_info: &mut RustInfo, path: Option<&Path>) {
     };
 }
 
-fn load_setup(rust_info: &mut RustInfo, path: Option<&Path>) {
+fn load_setup(rust_info: &mut RustInfo, options: &Options) {
     let mut command = Command::new("rustc");
 
     command.arg("--print").arg("cfg");
 
-    if let Some(directory) = path {
+    if let Some(directory) = &options.path {
         command.current_dir(directory);
     }
 
@@ -135,12 +134,12 @@ fn load_setup(rust_info: &mut RustInfo, path: Option<&Path>) {
 
 /// Loads and returns the current rust compiler version and setup.<br>
 /// In case partial data is not available, those values will be set to Option::None.
-pub(crate) fn get(path: Option<&Path>) -> RustInfo {
+pub(crate) fn get(options: &Options) -> RustInfo {
     let mut rust_info = RustInfo::new();
 
-    load_version(&mut rust_info, path);
+    load_version(&mut rust_info, options);
 
-    load_setup(&mut rust_info, path);
+    load_setup(&mut rust_info, options);
 
     triple::load(&mut rust_info);
 

--- a/src/rustinfo_test.rs
+++ b/src/rustinfo_test.rs
@@ -9,7 +9,7 @@ fn get_exit_code_error() {
 
 #[test]
 fn load_with_values() {
-    let rust_info = get();
+    let rust_info = get(None);
 
     assert!(rust_info.version.is_some());
     assert!(rust_info.channel.is_some());

--- a/tests/get_option_test.rs
+++ b/tests/get_option_test.rs
@@ -1,15 +1,11 @@
-use super::*;
-use std::io::ErrorKind;
+use std::path::Path;
+
+use rust_info::Options;
 
 #[test]
-fn get_exit_code_error() {
-    let code = get_exit_code(Err(Error::new(ErrorKind::Other, "test")));
-    assert_eq!(code, -1);
-}
-
-#[test]
-fn load_with_values() {
-    let rust_info = crate::get();
+fn get() {
+    let opts = Options::new().path(Some(Path::new("./").into()));
+    let rust_info = rust_info::get_with_options(&opts);
 
     assert!(rust_info.version.is_some());
     assert!(rust_info.channel.is_some());

--- a/tests/get_test.rs
+++ b/tests/get_test.rs
@@ -1,5 +1,3 @@
-use rust_info;
-
 #[test]
 fn get() {
     let rust_info = rust_info::get();


### PR DESCRIPTION
Adds a `get_path` function to the crate which allows you to specify a path which is set as the current working directory when calling rustc. This is useful for parsing project specific data (for example, when a `rust-toolchain` file exists). 